### PR TITLE
Add distributed cache using Redisson

### DIFF
--- a/src/main/java/uk/co/informaticslab/cache/RedisCache.java
+++ b/src/main/java/uk/co/informaticslab/cache/RedisCache.java
@@ -1,29 +1,50 @@
 package uk.co.informaticslab.cache;
 
+import org.redisson.Redisson;
+import org.redisson.api.*;
+import org.redisson.client.codec.JsonJacksonMapCodec;
+import org.redisson.config.Config;
+import uk.co.informaticslab.Constants;
+
 public class RedisCache implements Cache<String, byte[]> {
+
+    private RMapCache<String, byte[]> map;
+
+    public RedisCache(String redisAddress) {
+        Config config = new Config();
+
+        // todo: work out how to properly connect to Redis cluster
+        config.useSingleServer()
+                .setAddress(redisAddress);
+        RedissonClient redisson = Redisson.create(config);
+
+        // todo: consider LocalCachedMap to reduce network trips
+        map = redisson.getMapCache("opendap", new JsonJacksonMapCodec(String.class, byte[].class));
+    }
 
     @Override
     public boolean containsKey(String key) {
-        return false;
+        return map.containsKey(key);
     }
 
     @Override
     public void put(String key, byte[] value) {
-
+        map.fastPut(key, value);
+        System.out.println(map.readAllValues());
     }
 
     @Override
     public int size() {
-        return 0;
+        return map.size();
     }
 
     @Override
     public byte[] get(String key) {
-        return new byte[0];
+        return map.get(key);
     }
 
     @Override
     public Integer getMaxCacheSize() {
-        return null;
+        return Constants.MEGABYTE * 1000; // redisson doesn't currently support setting max size
     }
 }

--- a/src/test/java/uk/co/informaticslab/RedisCacheTest.java
+++ b/src/test/java/uk/co/informaticslab/RedisCacheTest.java
@@ -1,0 +1,61 @@
+package uk.co.informaticslab;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.embedded.RedisServer;
+import uk.co.informaticslab.cache.RedisCache;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RedisCacheTest {
+
+    private RedisServer redisServer;
+    private RedisCache redisCache;
+    private String redisAddress;
+
+    @Before
+    public void setUp() throws IOException {
+        redisServer = new RedisServer(6379);
+        redisServer.start();
+
+        redisAddress = "redis://127.0.0.1:6379";
+        redisCache = new RedisCache(redisAddress);
+    }
+
+    @After
+    public void tearDown() {
+        redisServer.stop();
+    }
+
+    @Test
+    public void testCache() {
+        byte[] data = "testing".getBytes();
+        String key = "test";
+        redisCache.put(key, data);
+
+        assertEquals(true, redisCache.containsKey(key));
+
+        byte[] result = redisCache.get(key);
+        assertTrue(Arrays.equals(data, result));
+    }
+
+    @Test
+    public void testPersistence() {
+        byte[] data = "testing".getBytes();
+        String key = "test";
+        redisCache.put(key, data);
+
+        RedisCache newCache = new RedisCache(redisAddress);
+        assertEquals(true, newCache.containsKey(key));
+
+        String newKey = "test2";
+        newCache.put(newKey, data);
+        assertEquals(true, redisCache.containsKey(newKey));
+    }
+
+}


### PR DESCRIPTION
Approach that uses Redisson to abstract away Redis. Not necessarily better than using Redis client directly. 

Advantage is we're basically just using a Map so code is very minimal and similar to local cache implementation. Disadvantage is additional library to depend on, abstraction may not be helpful

Raised for your interest @tpowellmeto, not saying we should definitely go this way.